### PR TITLE
fix cdn.unpkg when pathname omitted

### DIFF
--- a/packages/vite-plugin-monkey/src/node/cdn.ts
+++ b/packages/vite-plugin-monkey/src/node/cdn.ts
@@ -59,7 +59,11 @@ export const unpkg = (
     exportVarName,
     (version, name, _importName = '', resolveName = '') => {
       pathname ||= resolveName;
-      return `https://unpkg.com/${name}@${version}/${pathname}`;
+      if (pathname) {
+        return `https://unpkg.com/${name}@${version}/${pathname}`;
+      } else {
+        return `https://unpkg.com/${name}@${version}`;
+      }
     },
   ];
 };


### PR DESCRIPTION
jsdelivr 和 unpkg 一样. 
unpkg 缺少省略 pathname 逻辑