### PR TITLE
fix: remove extra space

### DIFF
--- a/packages/vite-plugin-monkey/src/node/userscript/index.ts
+++ b/packages/vite-plugin-monkey/src/node/userscript/index.ts
@@ -344,7 +344,7 @@ export const finalMonkeyOptionToComment = async ({
         return s;
       })
       .forEach((s) => {
-        s[1] += '\x20'.repeat(alignN + maxLen - s[1].length - 1);
+        s[1] += '\x20'.repeat(alignN + maxLen - s[1].length);
       });
 
     // format all
@@ -355,7 +355,9 @@ export const finalMonkeyOptionToComment = async ({
       }
     });
     attrList.forEach((s) => {
-      s[0] += '\x20'.repeat(alignN + maxLen - s[0].length - 1);
+      if (s[1]) {
+        s[0] = s[0].padEnd(alignN + maxLen, '\x20');
+      }
     });
   } else if (typeof align == 'function') {
     attrList = await align(attrList);
@@ -363,7 +365,7 @@ export const finalMonkeyOptionToComment = async ({
 
   return [
     '==UserScript==',
-    ...attrList.map((s) => '@' + s.join('\x20')),
+    ...attrList.map((s) => '@' + s.join('')),
     '==/UserScript==',
   ]
     .map((s) => '//\x20' + s)


### PR DESCRIPTION
UserScript的配置参数为布尔类型时, 对其设置(`format.align`)会使其行尾生成多个空格, 这些空格在油猴编辑器中被高亮显示, 影响美观.

before:
![image](https://user-images.githubusercontent.com/26848671/212809196-491d5f12-988e-44a7-8cba-a5486bc11fe4.png)

after:
![image](https://user-images.githubusercontent.com/26848671/212809130-75d62e18-9269-491b-8a04-872e7e081022.png)

