### PR TITLE
fix: notification highlight types

### DIFF
--- a/packages/vite-plugin-monkey/src/client/types/index.ts
+++ b/packages/vite-plugin-monkey/src/client/types/index.ts
@@ -124,7 +124,7 @@ export type NotificationDetails = {
   /**
    * @available tampermonkey
    */
-  highlight?: string;
+  highlight?: boolean;
   /**
    * @available tampermonkey
    */


### PR DESCRIPTION
> https://www.tampermonkey.net/documentation.php?locale=en#api:GM_notification

In fact, the type of `highlight` property in the `GM_notification` callback is boolean instead of string