### PR TITLE
fix: GM_log param type

### DIFF
--- a/packages/vite-plugin-monkey/src/client/types/index.ts
+++ b/packages/vite-plugin-monkey/src/client/types/index.ts
@@ -530,7 +530,7 @@ export type MonkeyWindow = typeof window & {
    * @see https://www.tampermonkey.net/documentation.php#GM_log
    * @available tampermonkey
    */
-  GM_log: (message: unknown) => void;
+  GM_log: (...data: any[]) => void;
 
   /**
    * @see https://www.tampermonkey.net/documentation.php#GM_notification


### PR DESCRIPTION
According to my tests, `GM_log` in tampermonkey acts similarly to `console.log`. It's description on <https://www.tampermonkey.net/documentation.php#api:GM_log> is not accurate.
```js
GM_log({a:1}, '123') // OK
GM_log('%d', 1) // doesn't support, prints "%d 1"
```
Tested on Tampermonkey v4.19.0.