### PR TITLE
feat: close preview automatically option

### DIFF
--- a/packages/vite-plugin-monkey/src/node/option.ts
+++ b/packages/vite-plugin-monkey/src/node/option.ts
@@ -294,6 +294,7 @@ export const resolvedOption = (
         server.open ??
         (process.platform == 'win32' || process.platform == 'darwin'),
       prefix: prefix2,
+      closePreviewAutomatically: server.closePreviewAutomatically ?? false,
     },
     build: {
       fileName,

--- a/packages/vite-plugin-monkey/src/node/plugins/perview.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/perview.ts
@@ -31,6 +31,11 @@ export const perviewPlugin = (finalOption: FinalMonkeyOption): Plugin => {
           return;
         }
         next();
+        if (finalOption.server.closePreviewAutomatically) {
+          setTimeout(() => {
+            server.close();
+          }, 3000);
+        }
       });
     },
   };

--- a/packages/vite-plugin-monkey/src/node/types.ts
+++ b/packages/vite-plugin-monkey/src/node/types.ts
@@ -95,6 +95,7 @@ export type FinalMonkeyOption = {
     open: boolean;
     prefix: (name: string) => string;
     mountGmApi: boolean;
+    closePreviewAutomatically: boolean;
   };
   build: {
     fileName: string;
@@ -157,6 +158,12 @@ export type MonkeyOption = {
      * @default 'server:'
      */
     prefix?: string | ((name: string) => string) | false;
+
+    /**
+     * close the preview server automatically after 3000ms
+     * @default false
+     */
+    closePreviewAutomatically?: boolean;
 
     /**
      * mount GM_api to unsafeWindow, not recommend it, you should use GM_api by ESM import, or use [unplugin-auto-import](https://github.com/antfu/unplugin-auto-import)


### PR DESCRIPTION
This PR adds a `server.closePreviewAutomatically` option (default `false`) which automatically closes the preview server (`npm run preview`) after 3000ms (arbitrary number).

No idea if this is something anyone wants (feel free to close if not) but to me it seems like the preview server is only used for getting the script data to the extension so might as well close it automatically to make going from dev to build and back a bit smoother.

I also have no idea what I'm doing so feel free to edit.

Usage:
`vite.config.ts`
```ts
server: {
        closePreviewAutomatically: true
      },
```

`package.json` (not needed but can be nice)
```json
    "build": "vite build",
    "postbuild": "vite preview",
```

Run `npm run build`, it builds, previews to let you reimport the script and closes automatically. Voila!
