### PR TITLE
Upgrade svelte-ts to version 5

### DIFF
--- a/packages/create-monkey/.gitignore
+++ b/packages/create-monkey/.gitignore
@@ -21,3 +21,4 @@ dist
 
 template-*/pnpm-lock.yaml
 template-*/package-lock.json
+template-*/bun.lockb

--- a/packages/create-monkey/template-svelte-ts/package.json
+++ b/packages/create-monkey/template-svelte-ts/package.json
@@ -7,17 +7,16 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json && tsc -p tsconfig.node.json"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.1.1",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tsconfig/svelte": "^5.0.4",
-    "svelte": "^4.2.17",
-    "svelte-check": "^3.8.0",
-    "svelte-preprocess": "^5.1.4",
-    "tslib": "^2.6.2",
-    "typescript": "^5.4.5",
-    "vite": "^5.2.12",
+    "svelte": "^5.1.3",
+    "svelte-check": "^4.0.5",
+    "tslib": "^2.8.0",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.10",
     "vite-plugin-monkey": "^4.0.0"
   }
 }

--- a/packages/create-monkey/template-svelte-ts/src/App.svelte
+++ b/packages/create-monkey/template-svelte-ts/src/App.svelte
@@ -6,7 +6,7 @@
 
 <main>
   <div>
-    <a href="https://vitejs.dev" target="_blank" rel="noreferrer">
+    <a href="https://vite.dev" target="_blank" rel="noreferrer">
       <img src={viteLogo} class="logo" alt="Vite Logo" />
     </a>
     <a href="https://svelte.dev" target="_blank" rel="noreferrer">
@@ -33,6 +33,7 @@
     height: 6em;
     padding: 1.5em;
     will-change: filter;
+    transition: filter 300ms;
   }
   .logo:hover {
     filter: drop-shadow(0 0 2em #646cffaa);

--- a/packages/create-monkey/template-svelte-ts/src/app.css
+++ b/packages/create-monkey/template-svelte-ts/src/app.css
@@ -1,7 +1,6 @@
 :root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light dark;
@@ -12,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-monkey/template-svelte-ts/src/lib/Counter.svelte
+++ b/packages/create-monkey/template-svelte-ts/src/lib/Counter.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  let count: number = 0
+  let count: number = $state(0)
   const increment = () => {
     count += 1
   }
 </script>
 
-<button on:click={increment}>
+<button onclick={increment}>
   count is {count}
 </button>

--- a/packages/create-monkey/template-svelte-ts/src/main.ts
+++ b/packages/create-monkey/template-svelte-ts/src/main.ts
@@ -1,12 +1,13 @@
+import { mount } from 'svelte';
 import './app.css';
 import App from './App.svelte';
 
-const app = new App({
+const app = mount(App, {
   target: (() => {
     const app = document.createElement('div');
     document.body.append(app);
     return app;
-  })(),
-});
+  })()
+})
 
 export default app;

--- a/packages/create-monkey/template-svelte-ts/svelte.config.js
+++ b/packages/create-monkey/template-svelte-ts/svelte.config.js
@@ -1,7 +1,7 @@
-import sveltePreprocess from 'svelte-preprocess';
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte"
 
 export default {
-  // Consult https://github.com/sveltejs/svelte-preprocess
+  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
   // for more information about preprocessors
-  preprocess: sveltePreprocess(),
+  preprocess: vitePreprocess(),
 };

--- a/packages/create-monkey/template-svelte-ts/tsconfig.json
+++ b/packages/create-monkey/template-svelte-ts/tsconfig.json
@@ -5,7 +5,6 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "resolveJsonModule": true,
-    "baseUrl": ".",
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.
      * Disable checkJs if you'd like to use dynamic types in JS.
@@ -13,13 +12,10 @@
      * of JS in `.svelte` files.
      */
     "allowJs": true,
-    "checkJs": true
-    // "isolatedModules": true
+    "checkJs": true,
+    "isolatedModules": true,
+    "moduleDetection": "force"
   },
-  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
-  "references": [
-    {
-      "path": "./tsconfig.node.json"
-    }
-  ]
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/create-monkey/template-svelte-ts/tsconfig.node.json
+++ b/packages/create-monkey/template-svelte-ts/tsconfig.node.json
@@ -1,8 +1,13 @@
 {
   "compilerOptions": {
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "skipLibCheck": true,
     "module": "ESNext",
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "strict": true,
+    "noEmit": true,
+    "noUncheckedSideEffectImports": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
This upgrades template-svelte-ts to version 5 and aligns the rest of the changes to the latest from the svelte package. I have validated that these changes allow the svelte ts template to load and run as before.

As time allows I can try to put up some PR's for some of the other package templates.