### PR TITLE
feat: Add support for importing external ES Modules

### DIFF
--- a/packages/vite-plugin-monkey/src/node/option.ts
+++ b/packages/vite-plugin-monkey/src/node/option.ts
@@ -116,6 +116,14 @@ export const resolvedOption = (
     Object.entries(externalGlobals2).forEach((s) => externalGlobals.push(s));
   }
 
+  const userExternalModules = build?.externalModules ?? {};
+  const externalModules: [string, string | Mod2UrlFn][] = [];
+  if (userExternalModules instanceof Array) {
+    userExternalModules.forEach((s) => externalModules.push(s));
+  } else {
+    Object.entries(userExternalModules).forEach((s) => externalModules.push(s));
+  }
+
   const { grant = [], $extra = [] } = pluginOption.userscript ?? {};
   let {
     name = {},
@@ -300,9 +308,11 @@ export const resolvedOption = (
       fileName,
       metaFileName: metaFileFc ? () => metaFileFc(fileName) : undefined,
       autoGrant: build.autoGrant ?? true,
-      externalGlobals: externalGlobals,
+      externalGlobals,
+      externalModules,
       externalResource: externalResource2,
     },
+    importsList: {},
     collectRequireUrls: [],
     collectResource: {},
     globalsPkg2VarName: {},

--- a/packages/vite-plugin-monkey/src/node/plugins/externalGlobals.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/externalGlobals.ts
@@ -53,7 +53,10 @@ export const externalGlobalsPlugin = (
         build: {
           rollupOptions: {
             external(source, _importer, _isResolved) {
-              return source in globalsPkg2VarName;
+              return (
+                source in finalOption.globalsPkg2VarName ||
+                source in finalOption.importsList
+              );
             },
             // output: {
             //   globals: globalsPkg2VarName,

--- a/packages/vite-plugin-monkey/src/node/plugins/externalModules.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/externalModules.ts
@@ -1,0 +1,42 @@
+import type { Plugin } from 'vite';
+import type { FinalMonkeyOption } from '../types';
+import { getModuleRealInfo } from '../_util';
+
+export const externalModulesPlugin = (
+  finalOption: FinalMonkeyOption,
+): Plugin => {
+  const { importsList } = finalOption;
+  return {
+    name: 'monkey:externalModules',
+    enforce: 'pre',
+    apply: 'build',
+    async config() {
+      for (const [moduleName, varName2LibUrl] of finalOption.build
+        .externalModules) {
+        const { name, version } = await getModuleRealInfo(moduleName);
+
+        if (typeof varName2LibUrl == 'string') {
+          importsList[moduleName] = varName2LibUrl;
+        } else if (typeof varName2LibUrl == 'function') {
+          importsList[moduleName] = await varName2LibUrl(
+            version,
+            name,
+            moduleName,
+          );
+        }
+      }
+      return {
+        build: {
+          rollupOptions: {
+            external(source, _importer, _isResolved) {
+              return (
+                source in finalOption.globalsPkg2VarName ||
+                source in finalOption.importsList
+              );
+            },
+          },
+        },
+      };
+    },
+  };
+};

--- a/packages/vite-plugin-monkey/src/node/plugins/index.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/index.ts
@@ -8,6 +8,7 @@ import { externalResourcePlugin } from './externalResource';
 import { finalBundlePlugin } from './finalBundle';
 import { perviewPlugin } from './perview';
 import { redirectClientPlugin } from './redirectClient';
+import { externalModulesPlugin } from './externalModules';
 
 const monkeyPluginList = [
   // only serve
@@ -21,6 +22,7 @@ const monkeyPluginList = [
   externalLoaderPlugin,
   externalResourcePlugin,
   externalGlobalsPlugin,
+  externalModulesPlugin,
 
   // only build, final build
   finalBundlePlugin,

--- a/packages/vite-plugin-monkey/src/node/types.ts
+++ b/packages/vite-plugin-monkey/src/node/types.ts
@@ -58,6 +58,10 @@ export type ExternalGlobals =
   | Record<string, IArray<string | Mod2UrlFn>>
   | [string, IArray<string | Mod2UrlFn>][];
 
+export type ExternalModules =
+  | Record<string, string | Mod2UrlFn>
+  | [string, string | Mod2UrlFn][];
+
 export type ExternalResource = Record<
   string,
   | string
@@ -103,6 +107,7 @@ export interface FinalMonkeyOption {
     metaFileName?: () => string;
     autoGrant: boolean;
     externalGlobals: [string, IArray<string | Mod2UrlFn>][];
+    externalModules: [string, string | Mod2UrlFn][];
     externalResource: Record<
       string,
       {
@@ -114,6 +119,7 @@ export interface FinalMonkeyOption {
     >;
   };
   collectRequireUrls: string[];
+  importsList: Record<string, string>;
   collectResource: Record<string, string>;
   globalsPkg2VarName: Record<string, string>;
   requirePkgList: { moduleName: string; url: string }[];
@@ -242,6 +248,13 @@ export interface MonkeyOption {
      * ]
      */
     externalGlobals?: ExternalGlobals;
+
+    /**
+     * same as `externalGlobals`, but the imports will be treated as modules
+     *
+     * @see https://github.com/lisonge/vite-plugin-monkey/issues/180
+     */
+    externalModules?: ExternalModules;
 
     /**
      * according to final code bundle, auto inject GM_* or GM.* to userscript comment grant


### PR DESCRIPTION
Resolve #180.

Pass the modules we want to externalise and their links to `externalModules`:

``` js
monkey({
  // ...
  build: {
    externalModules: {
      react: 'https://esm.sh/react@19.1.0',
      'react-dom': 'https://esm.sh/react-dom@19.1.0',
    },
  },
}),
```

``` js
import React, { useState } from 'react';
import ReactDOM from 'react-dom';

// ...
```

And the generated code will be as follows:

``` js
// ==UserScript==
// @name       esm support test
// @namespace  esm-support-test
// @version    1.0.0
// @author     VLTHellolin
// @match      https://www.google.com/
// ==/UserScript==

(async function () {
  'use strict';

  const require$$0 = await (import('https://esm.sh/react@19.1.0').then(m => m.default));
  const { useState } = await import('https://esm.sh/react@19.1.0');
  const require$$0$1  = await (import('https://esm.sh/react-dom@19.1.0').then(m => m.default));

  // ...

})();
```