### PR TITLE
fix(externalResourcePlugin): set enforce to pre

### DIFF
--- a/packages/vite-plugin-monkey/src/node/plugins/externalResource.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/externalResource.ts
@@ -18,6 +18,7 @@ export const externalResourcePlugin = (
   > = {};
   return {
     name: 'monkey:externalResource',
+    enforce: 'pre',
     apply: 'build',
     async config() {
       option = await getOption();


### PR DESCRIPTION
修改`externalResourcePlugin`的插件排序为`pre`。

刚刚把 [vite-plugin-monkey](https://github.com/lisonge/vite-plugin-monkey) 升到了6.0.0，在写 [BLTH](https://github.com/andywang425/BLTH/tree/dev) 这个项目的时候发现，build之后的用户脚本没有`@resource`元数据，代码里导入的CSS都是直接写在构建产物里。修改 externalResourcePlugin 的 enforce 修饰符为 pre 后能正常打包。

我的`vite.config.ts`的externalResource部分配置：
```ts
        externalResource: {
          'element-plus/dist/index.css': cdn.unpkg(),
          'element-plus/theme-chalk/dark/css-vars.css': cdn.unpkg(),
        },
```

我不太懂Vite插件开发，作者如果觉得不应该这么改就把PR关了吧。