### PR TITLE
chore: remove invalid CDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,6 @@ there is the following cdn to use, full detail see [cdn.ts](/packages/vite-plugi
 
 - [jsdelivr](https://www.jsdelivr.com/)
 - [unpkg](https://unpkg.com/)
-- [bytecdntp](https://cdn.bytedance.com/)
-- [baomitu](https://cdn.baomitu.com/)
 - [cdnjs](https://cdnjs.com/libraries)
 - [zhimg](https://unpkg.zhimg.com/)
 - [npmmirror](https://registry.npmmirror.com/)

--- a/README_zh.md
+++ b/README_zh.md
@@ -333,8 +333,6 @@ export default defineConfig({
 
 - [jsdelivr](https://www.jsdelivr.com/)
 - [unpkg](https://unpkg.com/)
-- [bytecdntp](https://cdn.bytedance.com/)
-- [baomitu](https://cdn.baomitu.com/)
 - [cdnjs](https://cdnjs.com/libraries)
 - [zhimg](https://unpkg.zhimg.com/)
 - [npmmirror](https://registry.npmmirror.com/)

--- a/packages/vite-plugin-monkey/src/node/cdn.ts
+++ b/packages/vite-plugin-monkey/src/node/cdn.ts
@@ -69,24 +69,6 @@ export const unpkg = (
 };
 
 /**
- * `https://lf9-cdn-tos.bytecdntp.com/cdn/expire-10-y/${name}/${version}/${pathname}`
- * @param exportVarName cdn-exportVarName or resourceName
- * @see https://cdn.bytedance.com/
- */
-export const bytecdntp = (
-  exportVarName = '',
-  pathname = '',
-): [string, ModuleToUrlFc] => {
-  return [
-    exportVarName,
-    (version, name, _importName = '', resolveName = '') => {
-      const p = pathname || resolveName;
-      return `https://lf9-cdn-tos.bytecdntp.com/cdn/expire-10-y/${name}/${version}/${p}`;
-    },
-  ];
-};
-
-/**
  * `https://fastly.jsdelivr.net/npm/${name}@${version}/${pathname}`
  * @deprecated bootcdn will return virus-infected code. Please stop using it and switch to other sources
  */
@@ -102,24 +84,6 @@ export const bootcdn = (
     (version, name, _importName = '', resolveName = '') => {
       const p = pathname || resolveName;
       return `https://fastly.jsdelivr.net/npm/${name}@${version}/${p}`;
-    },
-  ];
-};
-
-/**
- * `https://lib.baomitu.com/${name}/${version}/${pathname}`
- * @param exportVarName cdn-exportVarName or resourceName
- * @see https://cdn.baomitu.com/
- */
-export const baomitu = (
-  exportVarName = '',
-  pathname = '',
-): [string, ModuleToUrlFc] => {
-  return [
-    exportVarName,
-    (version, name, _importName = '', resolveName = '') => {
-      const p = pathname || resolveName;
-      return `https://lib.baomitu.com/${name}/${version}/${p}`;
     },
   ];
 };


### PR DESCRIPTION
bytedance cdn https://cdn.bytedance.com/ is down, see https://www.landiannews.com/archives/110179.html

baomitu cdn https://cdn.baomitu.com/ returns error, and website certificate has expired.

I just removed these two CDNs, are you considering marking them `@deprecated` and using jsdelivr as alternative?