### PR TITLE
feat: styleImport

### DIFF
--- a/packages/vite-plugin-monkey/src/node/index.ts
+++ b/packages/vite-plugin-monkey/src/node/index.ts
@@ -11,11 +11,12 @@ export * as cdn from './cdn';
 
 export default (pluginOption: MonkeyOption): Plugin[] => {
   let option: ResolvedMonkeyOption;
-  return factorys.map((f) =>
-    f(async () => {
-      return option || resolvedOption(pluginOption).then((v) => (option = v));
-    }),
-  );
+  const getOption = async () => {
+    return option || resolvedOption(pluginOption).then((v) => (option = v));
+  };
+  return factorys
+    .map((f) => f(getOption, pluginOption))
+    .filter(Boolean) as Plugin[];
 };
 
 /**

--- a/packages/vite-plugin-monkey/src/node/plugins/index.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/index.ts
@@ -1,5 +1,7 @@
+import type { MonkeyPluginFactory } from '../utils/types';
 import { buildBundleFactory } from './buildBundle';
 import { configFactory } from './config';
+import { cssFactory } from './css';
 import { externalGlobalsFactory } from './externalGlobals';
 import { externalResourceFactory } from './externalResource';
 import { fixAssetUrlFactory } from './fixAssetUrl';
@@ -8,10 +10,10 @@ import { fixCssUrlFactory } from './fixCssUrl';
 import { perviewFactory } from './perview';
 import { redirectClientFactory } from './redirectClient';
 import { serverFactory } from './server';
+import { styleFactory } from './style';
 import { virtualHtmlFactory } from './virtualHtml';
-import { cssFactory } from './css';
 
-const factorys = [
+const factorys: MonkeyPluginFactory[] = [
   configFactory,
 
   virtualHtmlFactory,
@@ -21,6 +23,7 @@ const factorys = [
   serverFactory,
   perviewFactory,
 
+  styleFactory,
   redirectClientFactory,
   externalGlobalsFactory,
   externalResourceFactory,

--- a/packages/vite-plugin-monkey/src/node/plugins/style.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/style.ts
@@ -1,0 +1,76 @@
+import { getUpperCaseName } from '../utils/others';
+import type { MonkeyPluginFactory } from '../utils/types';
+
+export const styleFactory: MonkeyPluginFactory = (_getOption, pluginOption) => {
+  if (pluginOption.styleImport === false) return;
+  let isServe: boolean;
+  return {
+    name: 'monkey:style',
+    enforce: 'pre',
+    async config(_, env) {
+      isServe = env.command === 'serve';
+    },
+    async resolveId(source, importer, options) {
+      if (source === toolsModId) return resolvedToolsModId;
+      if (source.endsWith(styleQuery)) {
+        const cssId = source.slice(0, -styleQuery.length);
+        const resolveId = (await this.resolve(cssId, importer, options))?.id;
+        if (!resolveId) return;
+        return resolveId + cssIdSuffix;
+      }
+    },
+    load(id) {
+      if (id === resolvedToolsModId) return toolsTemplate;
+      if (id.endsWith(cssIdSuffix)) {
+        const cssId = id.substring(0, id.length - cssIdSuffix.length);
+        return getStyleModule(cssId, isServe);
+      }
+    },
+  };
+};
+
+const styleQuery = '?style';
+
+const cssIdSuffix = '.plugin-monkey-style';
+
+const getStyleModule = (cssId: string, isServe: boolean): string => {
+  const name = getUpperCaseName(cssId.split('/').at(-1));
+  return (isServe ? styleDevTemplate : styleBuildTemplate)
+    .replaceAll('{0}', JSON.stringify(cssId + '?inline'))
+    .replaceAll('{1}', name || '_');
+};
+
+const toolsModId = 'virtual:monkey-style-tools';
+const resolvedToolsModId = '\0' + toolsModId;
+const toolsTemplate = `
+var a;
+export default (b) => ((a = document.createElement('style')), a.append(b), a);
+`.trimStart();
+
+const styleBuildTemplate = `
+import {1} from {0};
+import d from '${toolsModId}';
+export default d({1});
+`.trimStart();
+
+const styleDevTemplate = `
+import css from {0};
+import createStyle from '${toolsModId}';
+const style = createStyle(css);
+export default style;
+if (import.meta.hot) {
+  style.setAttribute('data-vite-dev-id', {0});
+  const nodes = [style];
+  const cloneNode = style.cloneNode;
+  style.cloneNode = function (...args) {
+    const s = cloneNode.call(this, ...args);
+    nodes.push(s);
+    return s;
+  };
+  import.meta.hot.accept({0}, (v) => {
+    const t = String(v.default || '');
+    nodes.forEach((s) => {
+      s.textContent = t;
+    });
+  });
+}`.trimStart();

--- a/packages/vite-plugin-monkey/src/node/utils/types.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/types.ts
@@ -1,3 +1,4 @@
+import type { Plugin } from 'vite';
 import type { FinalUserScript, MonkeyUserScript } from '../userscript';
 
 export type Thenable<T> = T | Promise<T>;
@@ -174,6 +175,28 @@ export interface MonkeyOption {
    * }
    */
   clientAlias?: string;
+
+  /**
+   * handle CSS imports as style nodes([HTMLStyleElement](https://developer.mozilla.org/docs/Web/API/HTMLStyleElement))
+   *
+   * If you use [Shadow DOM](https://developer.mozilla.org/docs/Web/API/Web_components/Using_shadow_DOM) (style isolation) to place your interface application, this is very useful.
+   *
+   * Support `.css?style`, `.less?style`, `.sass?style`, `.scss?style`, `.styl?style`, `.stylus?style`, `.pcss?style`, `.postcss?style` and `.sss?style` imports
+   *
+   * add `/// <reference types="vite-plugin-monkey/style" />` to vite-env.d.ts for type hint
+   *
+   * @example
+   * import style1 from './style1.css?style':
+   * import style2 from 'normalize.css?style';
+   * const container = document.createElement('div').attachShadow({ mode: 'open' });
+   * container.append(style1, style2); // with hmr when change style1.css
+   * const style3 = style1.cloneNode(); // it will still have hmr
+   *
+   * @default
+   * true
+   */
+  styleImport?: boolean;
+
   server?: {
     /**
      * auto open install url in default browser when userscript comment change
@@ -338,4 +361,11 @@ export interface MonkeyOption {
      */
     cssSideEffects?: string | ((css: string) => void);
   };
+}
+
+export interface MonkeyPluginFactory {
+  (
+    getOption: () => Promise<ResolvedMonkeyOption>,
+    pluginOption: MonkeyOption,
+  ): Plugin | undefined;
 }

--- a/packages/vite-plugin-monkey/style.d.ts
+++ b/packages/vite-plugin-monkey/style.d.ts
@@ -1,0 +1,4 @@
+declare module '*?style' {
+  const style: HTMLStyleElement;
+  export default style;
+}


### PR DESCRIPTION
```text
  /**
   * handle CSS imports as style nodes([HTMLStyleElement](https://developer.mozilla.org/docs/Web/API/HTMLStyleElement))
   *
   * If you use [Shadow DOM](https://developer.mozilla.org/docs/Web/API/Web_components/Using_shadow_DOM) (style isolation) to place your interface application, this is very useful.
   *
   * Support `.css?style`, `.less?style`, `.sass?style`, `.scss?style`, `.styl?style`, `.stylus?style`, `.pcss?style`, `.postcss?style` and `.sss?style` imports
   *
   * add `/// <reference types="vite-plugin-monkey/style" />` to vite-env.d.ts for type hint
   *
   * @example
   * import style1 from './style1.css?style':
   * import style2 from 'normalize.css?style';
   * const container = document.createElement('div').attachShadow({ mode: 'open' });
   * container.append(style1, style2); // with hmr when change style1.css
   * const style3 = style1.cloneNode(); // it will still have hmr
   *
   * @default
   * true
   */
  styleImport?: boolean;
```