### PR TITLE
fix: document.head may be null when run-at document-start (#262)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ export interface MonkeyOption {
      *   if (typeof GM_addStyle === 'function') {
      *     GM_addStyle(css);
      *   } else {
-     *     document.head.appendChild(document.createElement('style')).append(css)
+     *     (document.head || document.documentElement).appendChild(document.createElement('style')).append(css)
      *   }
      * };
      * @example

--- a/README_zh.md
+++ b/README_zh.md
@@ -315,7 +315,7 @@ export interface MonkeyOption {
      *   if (typeof GM_addStyle === 'function') {
      *     GM_addStyle(css);
      *   } else {
-     *     document.head.appendChild(document.createElement('style')).append(css)
+     *     (document.head || document.documentElement).appendChild(document.createElement('style')).append(css)
      *   }
      * };
      * @example

--- a/packages/vite-plugin-monkey/src/node/utils/others.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/others.ts
@@ -245,7 +245,10 @@ const defaultCssSideEffects = (css: string) => {
     // @ts-ignore
     GM_addStyle(css);
   } else {
-    document.head.appendChild(document.createElement('style')).append(css);
+    // see #262
+    (document.head || document.documentElement)
+      .appendChild(document.createElement('style'))
+      .append(css);
   }
 };
 

--- a/packages/vite-plugin-monkey/src/node/utils/template.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/template.ts
@@ -43,7 +43,9 @@ export const serverInjectFn = (entrySrc: string) => {
   } else {
     script.src = entrySrc;
   }
-  document.head.append(script);
+  // see #262
+  // document.head may be null when run-at document-start
+  (document.head || document.documentElement).append(script);
 };
 
 export const mountGmApiFn = (meta: ImportMeta, apiNames: string[] = []) => {

--- a/packages/vite-plugin-monkey/src/node/utils/types.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/types.ts
@@ -349,7 +349,7 @@ export interface MonkeyOption {
      *   if (typeof GM_addStyle === 'function') {
      *     GM_addStyle(css);
      *   } else {
-     *     document.head.appendChild(document.createElement('style')).append(css)
+     *     ((document.head || document.documentElement)).appendChild(document.createElement('style')).append(css)
      *   }
      * };
      * @example


### PR DESCRIPTION
fix #262

`document.head` -> `(document.head || document.documentElement)`

document.documentElement support append style/script/div