### PR TITLE
Feat/vite 8 support

### DIFF
--- a/packages/vite-plugin-monkey/package.json
+++ b/packages/vite-plugin-monkey/package.json
@@ -56,7 +56,7 @@
     "systemjs": "^6.15.1"
   },
   "peerDependencies": {
-    "vite": "^6.0.0 || ^7.0.0"
+    "vite": "^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "vite": {

--- a/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
@@ -1,5 +1,4 @@
-import type { OutputChunk, RollupOutput } from 'rollup';
-import type { Plugin, ResolvedConfig } from 'vite';
+import type { Plugin, ResolvedConfig, Rollup } from 'vite';
 import { build } from 'vite';
 import { finalMonkeyOptionToComment } from '../userscript';
 import { collectGrant } from '../utils/grant';
@@ -43,8 +42,8 @@ export const buildBundleFactory = (
       viteConfig = resolvedConfig;
     },
     async generateBundle(_, rawBundle) {
-      const entryChunks: OutputChunk[] = [];
-      const chunks: OutputChunk[] = [];
+      const entryChunks: Rollup.OutputChunk[] = [];
+      const chunks: Rollup.OutputChunk[] = [];
       Object.values(rawBundle).forEach((chunk) => {
         if (chunk.type == 'chunk') {
           if (chunk.facadeModuleId != polyfillId) {
@@ -115,7 +114,7 @@ export const buildBundleFactory = (
               const chunk = Object.values(rawBundle).find(
                 (chunk) =>
                   chunk.type == 'chunk' && source.endsWith(chunk.fileName),
-              ) as OutputChunk | undefined;
+              ) as Rollup.OutputChunk | undefined;
               if (chunk) {
                 return '\0' + source;
               }
@@ -182,7 +181,7 @@ export const buildBundleFactory = (
             fileName: () => `__entry.js`,
           },
         },
-      })) as RollupOutput[];
+      })) as Rollup.RollupOutput[];
       usedModules.forEach((k) => {
         if (fristEntryChunk != rawBundle[k]) {
           delete rawBundle[k];

--- a/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
@@ -1,5 +1,6 @@
-import type { Plugin, ResolvedConfig, Rollup } from 'vite';
+import type { Plugin, ResolvedConfig } from 'vite';
 import { build } from 'vite';
+import type { OutputChunk, RollupOutput } from '../utils/compat';
 import { finalMonkeyOptionToComment } from '../userscript';
 import { collectGrant } from '../utils/grant';
 import {
@@ -42,8 +43,8 @@ export const buildBundleFactory = (
       viteConfig = resolvedConfig;
     },
     async generateBundle(_, rawBundle) {
-      const entryChunks: Rollup.OutputChunk[] = [];
-      const chunks: Rollup.OutputChunk[] = [];
+      const entryChunks: OutputChunk[] = [];
+      const chunks: OutputChunk[] = [];
       Object.values(rawBundle).forEach((chunk) => {
         if (chunk.type == 'chunk') {
           if (chunk.facadeModuleId != polyfillId) {
@@ -114,7 +115,7 @@ export const buildBundleFactory = (
               const chunk = Object.values(rawBundle).find(
                 (chunk) =>
                   chunk.type == 'chunk' && source.endsWith(chunk.fileName),
-              ) as Rollup.OutputChunk | undefined;
+              ) as OutputChunk | undefined;
               if (chunk) {
                 return '\0' + source;
               }
@@ -181,7 +182,7 @@ export const buildBundleFactory = (
             fileName: () => `__entry.js`,
           },
         },
-      })) as Rollup.RollupOutput[];
+      })) as RollupOutput[];
       usedModules.forEach((k) => {
         if (fristEntryChunk != rawBundle[k]) {
           delete rawBundle[k];

--- a/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
@@ -1,5 +1,5 @@
 import type { Plugin, ResolvedConfig } from 'vite';
-import { build } from 'vite';
+import { build, version } from 'vite';
 import type { OutputChunk, RollupOutput } from '../utils/compat';
 import { finalMonkeyOptionToComment } from '../userscript';
 import { collectGrant } from '../utils/grant';
@@ -101,7 +101,8 @@ export const buildBundleFactory = (
       const buildResult = (await build({
         logLevel: 'error',
         configFile: false,
-        esbuild: false,
+        // Disable esbuild/oxc transforms — code is already transformed
+        ...(parseInt(version) < 8 ? { esbuild: false } : { oxc: false as any }),
         plugins: [
           {
             name: 'monkey:mock',

--- a/packages/vite-plugin-monkey/src/node/plugins/config.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/config.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from 'vite';
+import { version, type Plugin } from 'vite';
 import type { ResolvedMonkeyOption } from '../utils/types';
 
 export const configFactory = (
@@ -15,11 +15,14 @@ export const configFactory = (
             [option.clientAlias]: 'vite-plugin-monkey/dist/client',
           },
         },
-        esbuild: {
-          supported: {
-            'top-level-await': true,
+        // Rolldown (Vite 8+) supports top-level await natively
+        ...(parseInt(version) < 8 && {
+          esbuild: {
+            supported: {
+              'top-level-await': true,
+            },
           },
-        },
+        }),
         build: {
           assetsInlineLimit: Number.MAX_SAFE_INTEGER,
           chunkSizeWarningLimit: Number.MAX_SAFE_INTEGER,

--- a/packages/vite-plugin-monkey/src/node/plugins/css.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/css.ts
@@ -1,6 +1,7 @@
 import MagicString from 'magic-string';
 import fs from 'node:fs/promises';
-import type { Plugin, Rollup } from 'vite';
+import type { Plugin } from 'vite';
+import type { TransformPluginContext } from '../utils/compat';
 import {
   getProgramImportNodes,
   getSafeIdentifier,
@@ -56,7 +57,7 @@ export const cssFactory = (
 ): Plugin => {
   let option: ResolvedMonkeyOption;
   const isCssImport = async (
-    context: Rollup.TransformPluginContext,
+    context: TransformPluginContext,
     importer: string,
     value: string,
   ): Promise<boolean> => {

--- a/packages/vite-plugin-monkey/src/node/plugins/css.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/css.ts
@@ -1,7 +1,6 @@
 import MagicString from 'magic-string';
 import fs from 'node:fs/promises';
-import type { TransformPluginContext } from 'rollup';
-import type { Plugin } from 'vite';
+import type { Plugin, Rollup } from 'vite';
 import {
   getProgramImportNodes,
   getSafeIdentifier,
@@ -57,7 +56,7 @@ export const cssFactory = (
 ): Plugin => {
   let option: ResolvedMonkeyOption;
   const isCssImport = async (
-    context: TransformPluginContext,
+    context: Rollup.TransformPluginContext,
     importer: string,
     value: string,
   ): Promise<boolean> => {

--- a/packages/vite-plugin-monkey/src/node/plugins/fixCssUrl.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/fixCssUrl.ts
@@ -10,7 +10,8 @@ export const fixCssUrlFactory = (): Plugin => {
       return {
         css: {
           postcss: {
-            plugins: [postUrl({ url: 'inline' })],
+            // cast needed: postcss-url may resolve a different postcss version than vite
+            plugins: [postUrl({ url: 'inline' })] as any[],
           },
         },
       };

--- a/packages/vite-plugin-monkey/src/node/utils/compat.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/compat.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal type interfaces for Rollup/Rolldown compatibility.
+ *
+ * Vite 7 uses Rollup, Vite 8 uses Rolldown. The `Rollup` namespace
+ * re-exported by Vite doesn't always resolve correctly across both,
+ * so we define only the subset of types this plugin actually needs.
+ */
+
+export interface OutputChunk {
+  type: 'chunk';
+  code: string;
+  fileName: string;
+  isEntry: boolean;
+  facadeModuleId: string | null;
+  dynamicImports: string[];
+  modules: Record<string, { code: string | null }>;
+}
+
+export interface OutputAsset {
+  type: 'asset';
+  fileName: string;
+  source: string | Uint8Array;
+}
+
+export type OutputBundle = Record<string, OutputChunk | OutputAsset>;
+
+export interface RollupOutput {
+  output: (OutputChunk | OutputAsset)[];
+}
+
+export interface PluginContext {
+  parse(code: string, options?: any): any;
+  resolve(
+    source: string,
+    importer?: string,
+    options?: any,
+  ): Promise<{ id: string } | null>;
+  getModuleIds(): IterableIterator<string>;
+  emitFile(emittedFile: any): string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface TransformPluginContext extends PluginContext {}

--- a/packages/vite-plugin-monkey/src/node/utils/grant.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/grant.ts
@@ -1,10 +1,10 @@
 import * as acornWalk from 'acorn-walk';
-import type { Rollup } from 'vite';
+import type { OutputChunk, PluginContext } from './compat';
 import { grantNames } from './gmApi';
 
 export const collectGrant = (
-  context: Rollup.PluginContext,
-  chunks: Rollup.OutputChunk[],
+  context: PluginContext,
+  chunks: OutputChunk[],
   injectCssCode: string | undefined,
   minify: boolean,
 ): Set<string> => {

--- a/packages/vite-plugin-monkey/src/node/utils/grant.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/grant.ts
@@ -1,10 +1,10 @@
 import * as acornWalk from 'acorn-walk';
-import type { OutputChunk, PluginContext } from 'rollup';
+import type { Rollup } from 'vite';
 import { grantNames } from './gmApi';
 
 export const collectGrant = (
-  context: PluginContext,
-  chunks: OutputChunk[],
+  context: Rollup.PluginContext,
+  chunks: Rollup.OutputChunk[],
   injectCssCode: string | undefined,
   minify: boolean,
 ): Set<string> => {

--- a/packages/vite-plugin-monkey/src/node/utils/others.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/others.ts
@@ -3,8 +3,7 @@ import { resolve } from 'import-meta-resolve';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { ProgramNode } from 'rollup';
-import { transformWithEsbuild } from 'vite';
+import { transformWithEsbuild, type Rollup } from 'vite';
 import type { Thenable } from './types';
 
 export const isFirstBoot = (): boolean => {
@@ -177,7 +176,7 @@ export interface ImportNodeItem {
 }
 
 export const getProgramImportNodes = (
-  program: ProgramNode,
+  program: Rollup.ProgramNode,
 ): ImportNodeItem[] => {
   const nodes: ImportNodeItem[] = [];
   acornWalk.simple(program, {

--- a/packages/vite-plugin-monkey/src/node/utils/others.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/others.ts
@@ -3,7 +3,7 @@ import { resolve } from 'import-meta-resolve';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { transformWithEsbuild, type Rollup } from 'vite';
+import { transformWithEsbuild } from 'vite';
 import type { Thenable } from './types';
 
 export const isFirstBoot = (): boolean => {
@@ -175,9 +175,7 @@ export interface ImportNodeItem {
   value: string;
 }
 
-export const getProgramImportNodes = (
-  program: Rollup.ProgramNode,
-): ImportNodeItem[] => {
+export const getProgramImportNodes = (program: any): ImportNodeItem[] => {
   const nodes: ImportNodeItem[] = [];
   acornWalk.simple(program, {
     ImportDeclaration(node) {

--- a/packages/vite-plugin-monkey/src/node/utils/topLevelAwait.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/topLevelAwait.ts
@@ -1,7 +1,12 @@
 import type * as acorn from 'acorn';
 import * as acornWalk from 'acorn-walk';
 import MagicString from 'magic-string';
-import type { Rollup } from 'vite';
+import type {
+  OutputAsset,
+  OutputBundle,
+  OutputChunk,
+  PluginContext,
+} from './compat';
 
 interface AwaitCallExpression extends acorn.CallExpression {
   callee: acorn.Identifier;
@@ -10,7 +15,7 @@ interface AwaitCallExpression extends acorn.CallExpression {
 const awaitOffset = `await`.length;
 const initTlaIdentifier = `_TLA_`;
 
-export const getSafeTlaIdentifier = (rawBundle: Rollup.OutputBundle) => {
+export const getSafeTlaIdentifier = (rawBundle: OutputBundle) => {
   const codes: string[] = [];
   for (const chunk of Object.values(rawBundle)) {
     if (chunk.type == 'chunk') {
@@ -52,8 +57,8 @@ const includes = (
 };
 
 export const transformTlaToIdentifier = (
-  context: Rollup.PluginContext,
-  chunk: Rollup.OutputAsset | Rollup.OutputChunk,
+  context: PluginContext,
+  chunk: OutputAsset | OutputChunk,
   identifier: string,
 ) => {
   if (chunk.type == 'chunk') {
@@ -107,8 +112,8 @@ export const transformTlaToIdentifier = (
 };
 
 export const transformIdentifierToTla = (
-  context: Rollup.PluginContext,
-  chunk: Rollup.OutputAsset | Rollup.OutputChunk,
+  context: PluginContext,
+  chunk: OutputAsset | OutputChunk,
   identifier: string,
 ) => {
   if (chunk.type == 'chunk') {

--- a/packages/vite-plugin-monkey/src/node/utils/topLevelAwait.ts
+++ b/packages/vite-plugin-monkey/src/node/utils/topLevelAwait.ts
@@ -1,12 +1,7 @@
 import type * as acorn from 'acorn';
 import * as acornWalk from 'acorn-walk';
 import MagicString from 'magic-string';
-import type {
-  OutputAsset,
-  OutputBundle,
-  OutputChunk,
-  PluginContext,
-} from 'rollup';
+import type { Rollup } from 'vite';
 
 interface AwaitCallExpression extends acorn.CallExpression {
   callee: acorn.Identifier;
@@ -15,7 +10,7 @@ interface AwaitCallExpression extends acorn.CallExpression {
 const awaitOffset = `await`.length;
 const initTlaIdentifier = `_TLA_`;
 
-export const getSafeTlaIdentifier = (rawBundle: OutputBundle) => {
+export const getSafeTlaIdentifier = (rawBundle: Rollup.OutputBundle) => {
   const codes: string[] = [];
   for (const chunk of Object.values(rawBundle)) {
     if (chunk.type == 'chunk') {
@@ -57,8 +52,8 @@ const includes = (
 };
 
 export const transformTlaToIdentifier = (
-  context: PluginContext,
-  chunk: OutputAsset | OutputChunk,
+  context: Rollup.PluginContext,
+  chunk: Rollup.OutputAsset | Rollup.OutputChunk,
   identifier: string,
 ) => {
   if (chunk.type == 'chunk') {
@@ -112,8 +107,8 @@ export const transformTlaToIdentifier = (
 };
 
 export const transformIdentifierToTla = (
-  context: PluginContext,
-  chunk: OutputAsset | OutputChunk,
+  context: Rollup.PluginContext,
+  chunk: Rollup.OutputAsset | Rollup.OutputChunk,
   identifier: string,
 ) => {
   if (chunk.type == 'chunk') {


### PR DESCRIPTION
Add support for Vite 8 , keep backward support for Vite 7
Relates to #273 

 ### Summary

  - Add Vite 8 (Rolldown) compatibility while maintaining Vite 7 (Rollup) support
  - Drop Vite 6 from peer dependency range
  - Peer deps: `^6.0.0 || ^7.0.0` → `^7.0.0 || ^8.0.0`

  ### Problem

  Vite 8 replaced Rollup with Rolldown as its bundler. The plugin imported types
  directly from the `rollup` package, which is no longer a dependency in Vite 8.
  Additionally, Rolldown's types are structurally narrower than Rollup's, so even
  Vite's `Rollup` namespace re-exports don't type-check cleanly when both packages
  coexist in the dependency tree.
