### PR TITLE
fix: minify option regression

### DIFF
--- a/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
@@ -261,10 +261,10 @@ export const buildBundleFactory = (
             rolldownOptions: {
               external: Object.keys(option.globalsPkg2VarName),
               output: {
+                // disable rolldown minify when using terser or esbuild, see #280
                 ...(rolldownMinify !== undefined
                   ? { minify: rolldownMinify }
                   : {}),
-                // disable rolldown minify when using terser or esbuild
                 globals: option.globalsPkg2VarName,
                 comments: false,
                 strict: false, // rolldown will add 'use strict' to the file top instead of the wrapper function next line

--- a/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
@@ -242,6 +242,12 @@ export const buildBundleFactory = (
             (await getSystemjsTexts()).join('\n') + '\n' + finalJsCode;
         }
       } else {
+        const rolldownMinify =
+          (viteConfig.build.minify === undefined ||
+            viteConfig.build.minify === 'oxc') &&
+          !Array.isArray(viteConfig.build.rolldownOptions?.output)
+            ? viteConfig.build.rolldownOptions.output?.minify
+            : undefined;
         // use vite(rolldown) build iife
         const buildResult = (await build({
           logLevel: 'error',
@@ -255,12 +261,10 @@ export const buildBundleFactory = (
             rolldownOptions: {
               external: Object.keys(option.globalsPkg2VarName),
               output: {
-                minify:
-                  (viteConfig.build.minify === undefined ||
-                    viteConfig.build.minify === 'oxc') &&
-                  !Array.isArray(viteConfig.build.rolldownOptions?.output)
-                    ? viteConfig.build.rolldownOptions.output?.minify
-                    : false, // disable rolldown minify when using terser or esbuild
+                ...(rolldownMinify !== undefined
+                  ? { minify: rolldownMinify }
+                  : {}),
+                // disable rolldown minify when using terser or esbuild
                 globals: option.globalsPkg2VarName,
                 comments: false,
                 strict: false, // rolldown will add 'use strict' to the file top instead of the wrapper function next line

--- a/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
+++ b/packages/vite-plugin-monkey/src/node/plugins/buildBundle.ts
@@ -249,18 +249,18 @@ export const buildBundleFactory = (
           build: {
             write: false,
             minify,
+            terserOptions: viteConfig.build.terserOptions,
             target: 'esnext',
             modulePreload: false,
             rolldownOptions: {
               external: Object.keys(option.globalsPkg2VarName),
               output: {
-                minify: minify
-                  ? {
-                      mangle: false,
-                      compress: false,
-                      codegen: true,
-                    }
-                  : undefined,
+                minify:
+                  (viteConfig.build.minify === undefined ||
+                    viteConfig.build.minify === 'oxc') &&
+                  !Array.isArray(viteConfig.build.rolldownOptions?.output)
+                    ? viteConfig.build.rolldownOptions.output?.minify
+                    : false, // disable rolldown minify when using terser or esbuild
                 globals: option.globalsPkg2VarName,
                 comments: false,
                 strict: false, // rolldown will add 'use strict' to the file top instead of the wrapper function next line


### PR DESCRIPTION
fix #280 

`RolldownOptions.output` can also be an array (`OutputOptions[]`).
I’m not sure what the expected behavior should be in that case, so currently the plugin just disables rolldown minify when an output array is detected. Please take a look if there’s a preferred handling for multi-output configs.
